### PR TITLE
chore: housekeeping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
   push:
-    branches: [main, 'renovate/**']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
     types: [edited]
   push:
-    branches-ignore: [main]
+    branches-ignore: [main, v*]
   workflow_dispatch:
     inputs:
       log-level:
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: false
   workflow_run:
-    workflows: [Main]
+    workflows: [CI]
     branches: [main]
     types: [completed]
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,3 +4,9 @@ config:
   MD033:
     allowed_elements: [a, h3, img, p]
   MD041: false
+
+globs:
+  - '**/*.md'
+  - '!node_modules'
+  - '!.ai/**'
+  - '!.github/copilot-instructions.md'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,8 @@
         "xml"
     ],
 
+    "prettier.enable": false,
+
     "typescript.enablePromptUseWorkspaceTsdk": true,
     "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "bootstrap": "pnpm install --prefer-offline --loglevel warn",
     "build": "tsup",
     "build-release": "tsup --minify",
-    "check-types": "tsc",
-    "fix": "pnpm run lint --fix",
-    "lint": "eslint .",
+    "check-types": "tsc --noEmit",
+    "fix": "eslint --fix",
+    "lint": "eslint",
     "test": "vitest run"
   },
   "prettier": "@bfra.me/prettier-config/120-proof",


### PR DESCRIPTION
- Remove 'renovate/**' branch from CI push triggers
- Update Renovate to ignore 'v*' branches
- Change workflow reference in Renovate from 'Main' to 'CI'
- Disable Prettier in VSCode settings
- Modify linting scripts in package.json for consistency