### PR TITLE
chore: add `nano-staged` and `simple-git-hooks`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,20 @@
     "build-release": "tsup --minify",
     "check-types": "tsc --noEmit",
     "fix": "eslint --fix",
+    "postinstall": "simple-git-hooks",
     "lint": "eslint",
     "test": "vitest run"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm exec nano-staged"
+  },
+  "nano-staged": {
+    "*.{ts,js,jsx,tsx,css,md,json,yaml,yml}": [
+      "pnpm run fix"
+    ],
+    "package.json": [
+      "pnpx sort-package-json"
+    ]
   },
   "prettier": "@bfra.me/prettier-config/120-proof",
   "dependencies": {
@@ -45,8 +57,10 @@
     "eslint-plugin-prettier": "5.5.4",
     "jiti": "2.4.2",
     "js-yaml": "4.1.0",
+    "nano-staged": "0.8.0",
     "prettier": "3.6.2",
     "semantic-release": "24.2.7",
+    "simple-git-hooks": "2.13.1",
     "tsup": "8.5.0",
     "typescript": "5.8.3",
     "typescript-eslint": "8.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,12 +60,18 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
+      nano-staged:
+        specifier: 0.8.0
+        version: 0.8.0
       prettier:
         specifier: 3.6.2
         version: 3.6.2
       semantic-release:
         specifier: 24.2.7
         version: 24.2.7(typescript@5.8.3)
+      simple-git-hooks:
+        specifier: 2.13.1
+        version: 2.13.1
       tsup:
         specifier: 8.5.0
         version: 8.5.0(@swc/core@1.13.4)(jiti@2.1.2)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0)
@@ -2276,6 +2282,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nano-staged@0.8.0:
+    resolution: {integrity: sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2747,6 +2758,10 @@ packages:
   signale@1.4.0:
     resolution: {integrity: sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==}
     engines: {node: '>=6'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -5656,6 +5671,10 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nano-staged@0.8.0:
+    dependencies:
+      picocolors: 1.1.1
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.2: {}
@@ -6047,6 +6066,8 @@ snapshots:
       chalk: 2.4.2
       figures: 2.0.0
       pkg-conf: 2.1.0
+
+  simple-git-hooks@2.13.1: {}
 
   skin-tone@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ ignoreWorkspaceRootCheck: true
 
 onlyBuiltDependencies:
   - '@swc/core'
+  - simple-git-hooks
 
 overrides:
   jiti: <2.2.0


### PR DESCRIPTION
- Added postinstall script to run simple-git-hooks
- Configured nano-staged for pre-commit hooks
- Updated pnpm-workspace.yaml to include simple-git-hooks in onlyBuiltDependencies